### PR TITLE
Fix issues around restarting when config changes, restarting LLM connection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,7 @@
         "bun-types": "latest",
         "concurrently": "^9.1.2",
         "eslint": "^9.24.0",
+        "eslint-plugin-react-hooks": "^5.2.0",
         "prettier": "^3.5.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "spawn-rx": "^5.1.2",
@@ -550,6 +551,8 @@
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "eslint": ["eslint@9.24.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.20.0", "@eslint/config-helpers": "^0.2.0", "@eslint/core": "^0.12.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.24.0", "@eslint/plugin-kit": "^0.2.7", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.3.0", "eslint-visitor-keys": "^4.2.0", "espree": "^10.3.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@5.2.0", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg=="],
 
     "eslint-scope": ["eslint-scope@8.3.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,16 @@
 import eslint from '@eslint/js'
 import tseslint from '@typescript-eslint/eslint-plugin'
 import tsParser from '@typescript-eslint/parser'
+import reactHooks from 'eslint-plugin-react-hooks'
 
 export default [
   {
     ignores: ['node_modules/**', 'vite.config.ts'],
   },
+  // Config for .ts files (excluding .tsx)
   {
     files: ['**/*.ts'],
+    ignores: ['**/*.tsx'], // Explicitly ignore .tsx
     languageOptions: {
       parser: tsParser,
       parserOptions: {
@@ -30,6 +33,52 @@ export default [
       '@typescript-eslint/consistent-type-assertions': 'error',
       '@typescript-eslint/no-unnecessary-type-assertion': 'error',
       '@typescript-eslint/ban-ts-comment': 'error',
+    },
+  },
+  // Config for .tsx files (combining TS and React)
+  {
+    files: ['**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        project: './tsconfig.json',
+        ecmaFeatures: { jsx: true }, // Enable JSX parsing
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      // Include TS rules
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/consistent-type-assertions': 'error',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      '@typescript-eslint/ban-ts-comment': 'error',
+      // Include React Hooks rules
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+  // Config for .jsx files (React only)
+  {
+    files: ['**/*.jsx'],
+    // If you use standard JS in JSX, you might need a different parser or settings
+    // Add languageOptions if needed, e.g., for standard JS parser
+    plugins: {
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
     },
   },
 ]

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bun-types": "latest",
     "concurrently": "^9.1.2",
     "eslint": "^9.24.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "spawn-rx": "^5.1.2",

--- a/server/api.ts
+++ b/server/api.ts
@@ -136,7 +136,7 @@ export class ServerWebsocketApiImpl implements ServerWebsocketApi {
   }
 
   setConfig(config: AppConfig): Observable<void> {
-    return from(this.runtime.saveConfigAndReload(config))
+    return from(this.runtime.saveConfigAndClose(config))
   }
 
   handlePromptRequest(

--- a/server/eval-framework.ts
+++ b/server/eval-framework.ts
@@ -184,14 +184,16 @@ export class EvalHomeAssistantApi implements HomeAssistantApi {
   }
 }
 
-export async function createEvalRuntime(llm: LargeLanguageProvider) {
+export async function createEvalRuntime(
+  llmFactory: () => LargeLanguageProvider
+) {
   // Create a temporary notebook directory for eval mode
   const tmpNotebookDir = path.join(os.tmpdir(), 'beatrix-eval-notebook')
   await mkdir(tmpNotebookDir, { recursive: true })
 
   return new LiveAutomationRuntime(
     new EvalHomeAssistantApi(),
-    llm,
+    llmFactory,
     await createInMemoryDatabase(),
     tmpNotebookDir
   )

--- a/server/evals/call-service.ts
+++ b/server/evals/call-service.ts
@@ -8,8 +8,12 @@ import {
 import { LargeLanguageProvider, createBuiltinServers } from '../llm'
 
 // Basic service listing evaluation
-export async function* listServicesEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* listServicesEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
+
   yield await runScenario(
     llm,
     'What services are available for my living room lights?',
@@ -26,8 +30,12 @@ export async function* listServicesEval(llm: LargeLanguageProvider) {
 }
 
 // Basic light control evaluation
-export async function* lightControlEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* lightControlEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
+
   yield await runScenario(
     llm,
     'Turn on the kitchen chandelier light',
@@ -43,8 +51,11 @@ export async function* lightControlEval(llm: LargeLanguageProvider) {
 }
 
 // Advanced light control with brightness
-export async function* lightBrightnessEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* lightBrightnessEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Set the brightness of the living room lights to 50%',
@@ -61,8 +72,9 @@ export async function* lightBrightnessEval(llm: LargeLanguageProvider) {
 }
 
 // Light color control
-export async function* lightColorEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* lightColorEval(llmFactory: () => LargeLanguageProvider) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Make the bedroom lights blue',
@@ -79,8 +91,11 @@ export async function* lightColorEval(llm: LargeLanguageProvider) {
 }
 
 // Multiple entity control
-export async function* multipleEntityControlEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* multipleEntityControlEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Turn off all the lights in the living room and kitchen',
@@ -97,8 +112,11 @@ export async function* multipleEntityControlEval(llm: LargeLanguageProvider) {
 }
 
 // Media player control
-export async function* mediaPlayerControlEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* mediaPlayerControlEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Pause the TV in the living room',
@@ -116,9 +134,10 @@ export async function* mediaPlayerControlEval(llm: LargeLanguageProvider) {
 
 // Climate control with temperature
 export async function* climateControlTemperatureEval(
-  llm: LargeLanguageProvider
+  llmFactory: () => LargeLanguageProvider
 ) {
-  const runtime = await createEvalRuntime(llm)
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Set the thermostat in the bedroom to 72 degrees',
@@ -135,8 +154,11 @@ export async function* climateControlTemperatureEval(
 }
 
 // Climate control with mode
-export async function* climateControlModeEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* climateControlModeEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Switch the living room thermostat to heat mode',

--- a/server/evals/home-assistant.ts
+++ b/server/evals/home-assistant.ts
@@ -8,8 +8,11 @@ import {
 import { LargeLanguageProvider, createBuiltinServers } from '../llm'
 
 // Basic Home Assistant entity listing eval
-export async function* listEntitiesEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* listEntitiesEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'List all the light entities in the living room. Give me their friendly names only.',
@@ -30,8 +33,11 @@ export async function* listEntitiesEval(llm: LargeLanguageProvider) {
 }
 
 // Bulk operations on lights eval
-export async function* bulkLightOperationsEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* bulkLightOperationsEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Turn off all the lights in the kitchen.',
@@ -51,8 +57,11 @@ export async function* bulkLightOperationsEval(llm: LargeLanguageProvider) {
 }
 
 // Status checking across multiple entity types
-export async function* multiEntityStatusEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* multiEntityStatusEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Tell me about all the lights and media players that are currently on.',
@@ -74,8 +83,11 @@ export async function* multiEntityStatusEval(llm: LargeLanguageProvider) {
 }
 
 // Climate control evaluation
-export async function* climateControlEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* climateControlEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     "Set all thermostats to 72 degrees and make sure they're in heat mode.",
@@ -96,8 +108,11 @@ export async function* climateControlEval(llm: LargeLanguageProvider) {
 }
 
 // Scene activation evaluation
-export async function* sceneActivationEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* sceneActivationEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Activate the night mode opening scene.',
@@ -114,8 +129,11 @@ export async function* sceneActivationEval(llm: LargeLanguageProvider) {
 }
 
 // Entity attribute querying
-export async function* entityAttributeQueryEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* entityAttributeQueryEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'What is the current temperature and humidity in each room?',
@@ -132,8 +150,11 @@ export async function* entityAttributeQueryEval(llm: LargeLanguageProvider) {
 }
 
 // Complex multi-step automation
-export async function* complexAutomationEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* complexAutomationEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     "I'm leaving the house. Turn off all lights and make sure all media players are off.",

--- a/server/evals/notify.ts
+++ b/server/evals/notify.ts
@@ -8,8 +8,11 @@ import {
 import { LargeLanguageProvider, createBuiltinServers } from '../llm'
 
 // Basic notification target listing eval
-export async function* listNotifyTargetsEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* listNotifyTargetsEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'What are all the possible notification targets in my Home Assistant setup?',
@@ -26,8 +29,9 @@ export async function* listNotifyTargetsEval(llm: LargeLanguageProvider) {
 }
 
 // List people with notification capabilities
-export async function* listPeopleEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* listPeopleEval(llmFactory: () => LargeLanguageProvider) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Which people in my Home Assistant setup can receive notifications?',
@@ -44,8 +48,11 @@ export async function* listPeopleEval(llm: LargeLanguageProvider) {
 }
 
 // Send notification to specific person
-export async function* notifyPersonEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* notifyPersonEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Send a notification to Ani saying "Dinner is ready!"',
@@ -66,8 +73,11 @@ export async function* notifyPersonEval(llm: LargeLanguageProvider) {
 }
 
 // Send notification with title
-export async function* notifyWithTitleEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* notifyWithTitleEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Send a notification to Ulrike with the title "Urgent" and the message "Please call me back."',
@@ -84,8 +94,11 @@ export async function* notifyWithTitleEval(llm: LargeLanguageProvider) {
 }
 
 // Send to multiple people
-export async function* notifyMultiplePeopleEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* notifyMultiplePeopleEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Let both Ani and Effie know that "The movie is starting in 5 minutes."',
@@ -102,8 +115,11 @@ export async function* notifyMultiplePeopleEval(llm: LargeLanguageProvider) {
 }
 
 // Notify everyone
-export async function* notifyEveryoneEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* notifyEveryoneEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Send a notification to everyone in the house saying "Fire alarm test in 10 minutes."',
@@ -120,8 +136,11 @@ export async function* notifyEveryoneEval(llm: LargeLanguageProvider) {
 }
 
 // Notify specific device
-export async function* notifySpecificDeviceEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* notifySpecificDeviceEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'Send a notification specifically to Ani\'s its an flippi saying "Don\'t forget to bring your charger."',

--- a/server/evals/scheduling.ts
+++ b/server/evals/scheduling.ts
@@ -20,14 +20,17 @@ import {
   schedulerPrompt,
 } from '../workflow/scheduler-step'
 
-export async function* simplestSchedulerEval(llm: LargeLanguageProvider) {
+export async function* simplestSchedulerEval(
+  llmFactory: () => LargeLanguageProvider
+) {
   const inputAutomation = automationFromString(
     'Every Monday at 8:00 AM, turn on the living room lights.',
     'test_automation.md',
     true
   )
 
-  const service = await createEvalRuntime(llm)
+  const service = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   const tools = createDefaultSchedulerTools(service, inputAutomation)
 
   yield runScenario(
@@ -194,7 +197,9 @@ function findMultipleSchedulesGrader(
 }
 
 // --- Consolidated Absolute Time Evals ---
-export async function* evalAbsoluteTimePrompts(llm: LargeLanguageProvider) {
+export async function* evalAbsoluteTimePrompts(
+  llmFactory: () => LargeLanguageProvider
+) {
   // Scenario 1: Single specific date/time
   // const prompt1 =
   //   'Schedule my bedroom chandelier to turn on at 7:15am on April 25th, 2025'
@@ -209,7 +214,8 @@ export async function* evalAbsoluteTimePrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service2 = await createEvalRuntime(llm)
+  const service2 = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   const tools2 = createDefaultSchedulerTools(service2, inputAutomation2)
   const expected2: CronSignal[] = [
     { type: 'cron', cron: '0 7 * * *' },
@@ -230,14 +236,15 @@ export async function* evalAbsoluteTimePrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service7 = await createEvalRuntime(llm)
+  const service7 = await createEvalRuntime(llmFactory)
+  const llm7 = llmFactory()
   const tools7 = createDefaultSchedulerTools(service7, inputAutomation7)
   const expected7: CronSignal[] = [
     { type: 'cron', cron: '0 23 * * *' },
     { type: 'cron', cron: '0 3 * * *' },
   ]
   yield runScenario(
-    llm,
+    llm7,
     schedulerPrompt(service7, inputAutomation7.contents, ''),
     tools7,
     'Eval Absolute Time: Multiple times daily (becomes cron)',
@@ -252,7 +259,8 @@ export async function* evalAbsoluteTimePrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service8 = await createEvalRuntime(llm)
+  const service8 = await createEvalRuntime(llmFactory)
+  const llm8 = llmFactory()
   const tools8 = createDefaultSchedulerTools(service8, inputAutomation8)
   const expected8: CronSignal[] = [
     { type: 'cron', cron: '0 8 * * *' },
@@ -260,7 +268,7 @@ export async function* evalAbsoluteTimePrompts(llm: LargeLanguageProvider) {
     { type: 'cron', cron: '0 17 * * *' },
   ]
   yield runScenario(
-    llm,
+    llm8,
     schedulerPrompt(service8, inputAutomation8.contents, ''),
     tools8,
     'Eval Absolute Time: Multiple specific times daily (becomes cron)',
@@ -275,14 +283,15 @@ export async function* evalAbsoluteTimePrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service9 = await createEvalRuntime(llm)
+  const service9 = await createEvalRuntime(llmFactory)
+  const llm9 = llmFactory()
   const tools9 = createDefaultSchedulerTools(service9, inputAutomation9)
   const expected9: CronSignal[] = [
     { type: 'cron', cron: '45 6 * * 1-5' },
     { type: 'cron', cron: '30 8 * * 0,6' },
   ]
   yield runScenario(
-    llm,
+    llm9,
     schedulerPrompt(service9, inputAutomation9.contents, ''),
     tools9,
     'Eval Absolute Time: Weekday/Weekend split (becomes cron)',
@@ -291,7 +300,9 @@ export async function* evalAbsoluteTimePrompts(llm: LargeLanguageProvider) {
 }
 
 // --- Consolidated Cron Evals ---
-export async function* evalCronPrompts(llm: LargeLanguageProvider) {
+export async function* evalCronPrompts(
+  llmFactory: () => LargeLanguageProvider
+) {
   // Scenario 2: Weekday specific time
   const prompt2 = 'Turn on the bathroom overhead light at 8:00am on weekdays'
   const inputAutomation2 = automationFromString(
@@ -299,7 +310,8 @@ export async function* evalCronPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service2 = await createEvalRuntime(llm)
+  const service2 = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   const tools2 = createDefaultSchedulerTools(service2, inputAutomation2)
   const expected2: CronSignal = {
     type: 'cron',
@@ -323,14 +335,15 @@ export async function* evalCronPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service3 = await createEvalRuntime(llm)
+  const service3 = await createEvalRuntime(llmFactory)
+  const llm3 = llmFactory()
   const tools3 = createDefaultSchedulerTools(service3, inputAutomation3)
   const expected3: CronSignal = {
     type: 'cron',
     cron: '0 0 1 * *',
   }
   yield runScenario(
-    llm,
+    llm3,
     schedulerPrompt(service3, inputAutomation3.contents, ''),
     tools3,
     'Eval Cron: End of month (becomes start of next month)',
@@ -342,7 +355,9 @@ export async function* evalCronPrompts(llm: LargeLanguageProvider) {
 }
 
 // --- Consolidated Mixed Signal Evals ---
-export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
+export async function* evalMixedPrompts(
+  llmFactory: () => LargeLanguageProvider
+) {
   // Scenario 1: Sunset and Sunrise (becomes state triggers)
   const prompt1 =
     'Turn on the foyer bird sconces at sunset and turn them off at sunrise'
@@ -351,7 +366,8 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service1 = await createEvalRuntime(llm)
+  const service1 = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   const tools1 = createDefaultSchedulerTools(service1, inputAutomation1)
   const expected1: StateRegexSignal[] = [
     { type: 'state', entityIds: ['sun.sun'], regex: '^below_horizon$' },
@@ -373,7 +389,8 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service2 = await createEvalRuntime(llm)
+  const service2 = await createEvalRuntime(llmFactory)
+  const llm2 = llmFactory()
   const tools2 = createDefaultSchedulerTools(service2, inputAutomation2)
   const expected2: StateRegexSignal = {
     type: 'state',
@@ -381,7 +398,7 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     regex: '^home$',
   }
   yield runScenario(
-    llm,
+    llm2,
     schedulerPrompt(service2, inputAutomation2.contents, ''),
     tools2,
     'Eval Mixed: State trigger (person arrives)',
@@ -399,14 +416,15 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service3 = await createEvalRuntime(llm)
+  const service3 = await createEvalRuntime(llmFactory)
+  const llm3 = llmFactory()
   const tools3 = createDefaultSchedulerTools(service3, inputAutomation3)
   const expected3: CronSignal = {
     type: 'cron',
     cron: '0 22 * * *',
   }
   yield runScenario(
-    llm,
+    llm3,
     schedulerPrompt(service3, inputAutomation3.contents, ''),
     tools3,
     'Eval Mixed: Time condition (becomes cron) + state condition',
@@ -424,7 +442,8 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service4 = await createEvalRuntime(llm)
+  const service4 = await createEvalRuntime(llmFactory)
+  const llm4 = llmFactory()
   const tools4 = createDefaultSchedulerTools(service4, inputAutomation4)
   const expected4: StateRegexSignal = {
     type: 'state',
@@ -432,7 +451,7 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     regex: '^on$',
   }
   yield runScenario(
-    llm,
+    llm4,
     schedulerPrompt(service4, inputAutomation4.contents, ''),
     tools4,
     'Eval Mixed: State trigger (relative time handled post-trigger)',
@@ -450,7 +469,8 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service5 = await createEvalRuntime(llm)
+  const service5 = await createEvalRuntime(llmFactory)
+  const llm5 = llmFactory()
   const tools5 = createDefaultSchedulerTools(service5, inputAutomation5)
   const expected5: (CronSignal | StateRegexSignal)[] = [
     { type: 'cron', cron: '0 8 * * *' },
@@ -461,7 +481,7 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     },
   ]
   yield runScenario(
-    llm,
+    llm5,
     schedulerPrompt(service5, inputAutomation5.contents, ''),
     tools5,
     'Eval Mixed: Cron and State trigger',
@@ -476,7 +496,8 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service6 = await createEvalRuntime(llm)
+  const service6 = await createEvalRuntime(llmFactory)
+  const llm6 = llmFactory()
   const tools6 = createDefaultSchedulerTools(service6, inputAutomation6)
   const expected6: (CronSignal | StateRegexSignal)[] = [
     { type: 'cron', cron: '0 23 * * *' },
@@ -487,7 +508,7 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     },
   ]
   yield runScenario(
-    llm,
+    llm6,
     schedulerPrompt(service6, inputAutomation6.contents, ''),
     tools6,
     'Eval Mixed: Cron or State trigger',
@@ -502,7 +523,8 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service7 = await createEvalRuntime(llm)
+  const service7 = await createEvalRuntime(llmFactory)
+  const llm7 = llmFactory()
   const tools7 = createDefaultSchedulerTools(service7, inputAutomation7)
   const expected7: StateRegexSignal = {
     type: 'state',
@@ -510,7 +532,7 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     regex: '^below_horizon$',
   }
   yield runScenario(
-    llm,
+    llm7,
     schedulerPrompt(service7, inputAutomation7.contents, ''),
     tools7,
     'Eval Mixed: Sunset trigger with complex state/duration condition',
@@ -528,7 +550,8 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service9 = await createEvalRuntime(llm)
+  const service9 = await createEvalRuntime(llmFactory)
+  const llm9 = llmFactory()
   const tools9 = createDefaultSchedulerTools(service9, inputAutomation9)
   const expected9: (CronSignal | StateRegexSignal)[] = [
     { type: 'cron', cron: '0 22 * * *' },
@@ -539,7 +562,7 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
     },
   ]
   yield runScenario(
-    llm,
+    llm9,
     schedulerPrompt(service9, inputAutomation9.contents, ''),
     tools9,
     'Eval Mixed: Cron and State trigger (with time condition on state)',
@@ -548,7 +571,9 @@ export async function* evalMixedPrompts(llm: LargeLanguageProvider) {
 }
 
 // --- Consolidated Relative Time Evals ---
-export async function* evalRelativeTimePrompts(llm: LargeLanguageProvider) {
+export async function* evalRelativeTimePrompts(
+  llmFactory: () => LargeLanguageProvider
+) {
   // Scenario 1: State trigger (offset handled post-trigger)
   const prompt1 =
     'Turn off the living room overhead light 30 minutes after ani leaves the house'
@@ -557,7 +582,8 @@ export async function* evalRelativeTimePrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service1 = await createEvalRuntime(llm)
+  const service1 = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   const tools1 = createDefaultSchedulerTools(service1, inputAutomation1)
   const expected1: StateRegexSignal = {
     type: 'state',
@@ -582,14 +608,15 @@ export async function* evalRelativeTimePrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service2 = await createEvalRuntime(llm)
+  const service2 = await createEvalRuntime(llmFactory)
+  const llm2 = llmFactory()
   const tools2 = createDefaultSchedulerTools(service2, inputAutomation2)
   const expected2: RelativeTimeSignal = {
     type: 'offset',
     offsetInSeconds: 45 * 60,
   }
   yield runScenario(
-    llm,
+    llm2,
     schedulerPrompt(service2, inputAutomation2.contents, ''),
     tools2,
     'Eval Relative Time: Simple offset trigger',
@@ -607,7 +634,8 @@ export async function* evalRelativeTimePrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service4 = await createEvalRuntime(llm)
+  const service4 = await createEvalRuntime(llmFactory)
+  const llm4 = llmFactory()
   const tools4 = createDefaultSchedulerTools(service4, inputAutomation4)
   const expected4: StateRegexSignal = {
     type: 'state',
@@ -615,7 +643,7 @@ export async function* evalRelativeTimePrompts(llm: LargeLanguageProvider) {
     regex: '^not_home$',
   }
   yield runScenario(
-    llm,
+    llm4,
     schedulerPrompt(service4, inputAutomation4.contents, ''),
     tools4,
     'Eval Relative Time: Group state trigger (offset handled post-trigger)',
@@ -633,14 +661,15 @@ export async function* evalRelativeTimePrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service5 = await createEvalRuntime(llm)
+  const service5 = await createEvalRuntime(llmFactory)
+  const llm5 = llmFactory()
   const tools5 = createDefaultSchedulerTools(service5, inputAutomation5)
   const expected5: CronSignal = {
     type: 'cron',
     cron: '*/15 * * * *',
   }
   yield runScenario(
-    llm,
+    llm5,
     schedulerPrompt(service5, inputAutomation5.contents, ''),
     tools5,
     'Eval Relative Time: Recurring action with state condition (becomes cron)',
@@ -658,14 +687,15 @@ export async function* evalRelativeTimePrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service7 = await createEvalRuntime(llm)
+  const service7 = await createEvalRuntime(llmFactory)
+  const llm7 = llmFactory()
   const tools7 = createDefaultSchedulerTools(service7, inputAutomation7)
   const expected7: CronSignal = {
     type: 'cron',
     cron: '0,30 16-23 * * *',
   }
   yield runScenario(
-    llm,
+    llm7,
     schedulerPrompt(service7, inputAutomation7.contents, ''),
     tools7,
     'Eval Relative Time: Recurring action after specific time (becomes cron)',
@@ -677,7 +707,9 @@ export async function* evalRelativeTimePrompts(llm: LargeLanguageProvider) {
 }
 
 // --- Consolidated State Regex Evals ---
-export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
+export async function* evalStateRegexPrompts(
+  llmFactory: () => LargeLanguageProvider
+) {
   // Scenario 1: Any person arrives (group state)
   const prompt1 = 'Turn on the foyer bird sconces when any person arrives home'
   const inputAutomation1 = automationFromString(
@@ -685,7 +717,8 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service1 = await createEvalRuntime(llm)
+  const service1 = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   const tools1 = createDefaultSchedulerTools(service1, inputAutomation1)
   const expected1: StateRegexSignal = {
     type: 'state',
@@ -710,7 +743,8 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service2 = await createEvalRuntime(llm)
+  const service2 = await createEvalRuntime(llmFactory)
+  const llm2 = llmFactory()
   const tools2 = createDefaultSchedulerTools(service2, inputAutomation2)
   const expected2: StateRegexSignal = {
     type: 'state',
@@ -718,7 +752,7 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     regex: '^off$',
   }
   yield runScenario(
-    llm,
+    llm2,
     schedulerPrompt(service2, inputAutomation2.contents, ''),
     tools2,
     'Eval State Regex: Specific entity turns off',
@@ -736,7 +770,8 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service4 = await createEvalRuntime(llm)
+  const service4 = await createEvalRuntime(llmFactory)
+  const llm4 = llmFactory()
   const tools4 = createDefaultSchedulerTools(service4, inputAutomation4)
   const expected4: StateRegexSignal = {
     type: 'state',
@@ -744,7 +779,7 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     regex: '^on$',
   }
   yield runScenario(
-    llm,
+    llm4,
     schedulerPrompt(service4, inputAutomation4.contents, ''),
     tools4,
     'Eval State Regex: Specific entity turns on',
@@ -762,7 +797,8 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service7 = await createEvalRuntime(llm)
+  const service7 = await createEvalRuntime(llmFactory)
+  const llm7 = llmFactory()
   const tools7 = createDefaultSchedulerTools(service7, inputAutomation7)
   const expected7: StateRegexSignal = {
     type: 'state',
@@ -770,7 +806,7 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     regex: '^on$',
   }
   yield runScenario(
-    llm,
+    llm7,
     schedulerPrompt(service7, inputAutomation7.contents, ''),
     tools7,
     'Eval State Regex: Update entity changes state (to on)',
@@ -787,7 +823,8 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service8 = await createEvalRuntime(llm)
+  const service8 = await createEvalRuntime(llmFactory)
+  const llm8 = llmFactory()
   const tools8 = createDefaultSchedulerTools(service8, inputAutomation8)
   const expected8: StateRegexSignal = {
     type: 'state',
@@ -795,7 +832,7 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     regex: '^off$',
   }
   yield runScenario(
-    llm,
+    llm8,
     schedulerPrompt(service8, inputAutomation8.contents, ''),
     tools8,
     'Eval State Regex: Input boolean turns off',
@@ -811,7 +848,8 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     'test_automation.md',
     true
   )
-  const service9 = await createEvalRuntime(llm)
+  const service9 = await createEvalRuntime(llmFactory)
+  const llm9 = llmFactory()
   const tools9 = createDefaultSchedulerTools(service9, inputAutomation9)
   const expected9: StateRegexSignal = {
     type: 'state',
@@ -819,7 +857,7 @@ export async function* evalStateRegexPrompts(llm: LargeLanguageProvider) {
     regex: '^on$',
   }
   yield runScenario(
-    llm,
+    llm9,
     schedulerPrompt(service9, inputAutomation9.contents, ''),
     tools9,
     'Eval State Regex: Input boolean changes to on',

--- a/server/evals/simple-evals.ts
+++ b/server/evals/simple-evals.ts
@@ -7,7 +7,8 @@ import {
 } from '../eval-framework'
 import { LargeLanguageProvider, createBuiltinServers } from '../llm'
 
-export async function* smokeTestEval(llm: LargeLanguageProvider) {
+export async function* smokeTestEval(llmFactory: () => LargeLanguageProvider) {
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'What is the capital of France?',
@@ -23,8 +24,11 @@ export async function* smokeTestEval(llm: LargeLanguageProvider) {
   )
 }
 
-export async function* smokeTestToolsEval(llm: LargeLanguageProvider) {
-  const runtime = await createEvalRuntime(llm)
+export async function* smokeTestToolsEval(
+  llmFactory: () => LargeLanguageProvider
+) {
+  const runtime = await createEvalRuntime(llmFactory)
+  const llm = llmFactory()
   yield await runScenario(
     llm,
     'What lights are in the foyer? Tell me the friendly names of each light.',

--- a/server/index.ts
+++ b/server/index.ts
@@ -149,7 +149,6 @@ async function evalCommand(options: {
   const { model, driver } = options
 
   const config = await createConfigViaEnv(options.notebook)
-  const llm = createDefaultLLMProvider(config, driver, model)
 
   console.log(`Running ${options.quick ? 'quick' : 'all'} evals...`)
   const results = []
@@ -157,7 +156,9 @@ async function evalCommand(options: {
     console.log(`Run ${i + 1} of ${options.num}`)
 
     const evalFunction = options.quick ? runQuickEvals : runAllEvals
-    for await (const result of evalFunction(llm)) {
+    for await (const result of evalFunction(() =>
+      createDefaultLLMProvider(config, driver, model)
+    )) {
       results.push(result)
       if (options.verbose) {
         console.log(JSON.stringify(result, null, 2))

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,11 +6,11 @@ import { configDotenv } from 'dotenv'
 import { mkdir } from 'fs/promises'
 import { sql } from 'kysely'
 import path from 'path'
-import { Subject, filter } from 'rxjs'
+import { Observable, Subject, Subscription, filter, mergeMap } from 'rxjs'
 
-import packageJson from '../package.json'
 import pkg from '../package.json'
 import { ServerWebsocketApi, messagesToString } from '../shared/api'
+import { SerialSubscription } from '../shared/serial-subscription'
 import { ScenarioResult } from '../shared/types'
 import { ServerMessage } from '../shared/ws-rpc'
 import { ServerWebsocketApiImpl } from './api'
@@ -40,39 +40,11 @@ async function serveCommand(options: {
   evalMode: boolean
 }) {
   const port = options.port || process.env.PORT || DEFAULT_PORT
-  const config = await createConfigViaEnv(options.notebook)
-
-  const conn = options.evalMode
-    ? new EvalHomeAssistantApi()
-    : await LiveHomeAssistantApi.createViaConfig(config)
-
-  const db = await createDatabaseViaEnv()
-  await startLogger(db, config.timezone ?? 'Etc/UTC')
-
-  await mkdir(path.join(options.notebook, 'automations'), {
-    recursive: true,
-  })
-
-  const runtime = await LiveAutomationRuntime.createViaConfig(
-    config,
-    conn,
-    path.resolve(options.notebook)
-  )
+  const websocketMessages: Subject<ServerMessage> = new Subject()
+  const startItUp: Subject<void> = new Subject()
 
   console.log(
     `Starting server on port ${port} (testMode: ${options.testMode || options.evalMode}, evalMode: ${options.evalMode})`
-  )
-
-  const subj: Subject<ServerMessage> = new Subject()
-  handleWebsocketRpc<ServerWebsocketApi>(
-    new ServerWebsocketApiImpl(
-      config,
-      runtime,
-      path.resolve(options.notebook),
-      options.testMode,
-      options.evalMode
-    ),
-    subj
   )
 
   if (isProdMode) {
@@ -81,11 +53,31 @@ async function serveCommand(options: {
     i('Running in development server-only mode')
   }
 
-  runtime.start()
+  const currentSub = new SerialSubscription()
+  let currentRuntime: AutomationRuntime
+
+  startItUp
+    .pipe(
+      mergeMap(async () => {
+        i('Starting up Runtime')
+        let { runtime, subscription } = await initializeRuntimeAndStart(
+          options.notebook,
+          options.evalMode,
+          options.testMode,
+          websocketMessages
+        )
+
+        runtime.shouldRestart.subscribe(() => startItUp.next(undefined))
+
+        currentSub.current = subscription
+        currentRuntime = runtime
+      })
+    )
+    .subscribe()
 
   // Setup graceful shutdown handler
   process.on('SIGINT', () => {
-    void flushAndExit(runtime)
+    if (currentRuntime) void flushAndExit(currentRuntime)
   })
 
   const assetsServer = serveStatic(path.join(repoRootDir(), 'public'))
@@ -102,7 +94,7 @@ async function serveCommand(options: {
     },
     websocket: {
       async message(ws: ServerWebSocket, message: string | Buffer) {
-        subj.next({
+        websocketMessages.next({
           message: message,
           reply: async (m) => {
             ws.send(m, true)
@@ -111,6 +103,8 @@ async function serveCommand(options: {
       },
     },
   })
+
+  startItUp.next(undefined)
 }
 
 async function mcpCommand(options: { testMode: boolean; notebook: string }) {
@@ -207,6 +201,64 @@ async function dumpEventsCommand() {
     })
 }
 
+async function initializeRuntimeAndStart(
+  notebook: string,
+  evalMode: boolean,
+  testMode: boolean,
+  websocketMessages: Observable<ServerMessage>
+) {
+  const subscription = new Subscription()
+  const config = await createConfigViaEnv(notebook)
+
+  await mkdir(path.join(notebook, 'automations'), {
+    recursive: true,
+  })
+
+  const conn = evalMode
+    ? new EvalHomeAssistantApi()
+    : await LiveHomeAssistantApi.createViaConfig(config)
+
+  const db = await createDatabaseViaEnv()
+  subscription.add(await startLogger(db, config.timezone ?? 'Etc/UTC'))
+
+  const runtime = await LiveAutomationRuntime.createViaConfig(
+    config,
+    conn,
+    path.resolve(notebook)
+  )
+
+  handleWebsocketRpc<ServerWebsocketApi>(
+    new ServerWebsocketApiImpl(
+      config,
+      runtime,
+      path.resolve(notebook),
+      testMode,
+      evalMode
+    ),
+    websocketMessages
+  )
+
+  subscription.add(runtime.start())
+  return { runtime, subscription }
+}
+
+async function flushAndExit(runtime: AutomationRuntime) {
+  try {
+    console.log('Flushing database...')
+
+    // Run PRAGMA commands to ensure database integrity during shutdown
+    await sql`PRAGMA wal_checkpoint(FULL)`.execute(runtime.db)
+
+    // Close database connection
+    await runtime.db.destroy()
+    runtime.unsubscribe()
+  } catch (error) {
+    console.error('Error during shutdown:', error)
+  }
+
+  process.exit(0)
+}
+
 async function main() {
   const program = new Command()
   const debugMode = process.execPath.endsWith('bun')
@@ -214,7 +266,7 @@ async function main() {
   program
     .name('beatrix')
     .description('Home Assistant Agentic Automation')
-    .version(packageJson.version)
+    .version(pkg.version)
 
   program
     .command('serve')
@@ -284,22 +336,6 @@ async function main() {
   }
 
   await program.parseAsync()
-}
-
-async function flushAndExit(runtime: AutomationRuntime) {
-  try {
-    console.log('Flushing database...')
-
-    // Run PRAGMA commands to ensure database integrity during shutdown
-    await sql`PRAGMA wal_checkpoint(FULL)`.execute(runtime.db)
-
-    // Close database connection
-    await runtime.db.destroy()
-  } catch (error) {
-    console.error('Error during shutdown:', error)
-  }
-
-  process.exit(0)
 }
 
 main().catch((err) => {

--- a/server/logging.ts
+++ b/server/logging.ts
@@ -26,7 +26,7 @@ export async function startLogger(db: Kysely<Schema>, timezone: string) {
   }
 
   const subj = new Subject<{ msg: string; type: string; timestamp: DateTime }>()
-  subj
+  const sub = subj
     .pipe(
       bufferTime(750),
       concatMap((msgs) => {
@@ -61,6 +61,8 @@ export async function startLogger(db: Kysely<Schema>, timezone: string) {
   } catch (err) {
     console.error('Error cleaning up old logs:', err)
   }
+
+  return sub
 }
 
 /**

--- a/server/mcp/home-assistant.ts
+++ b/server/mcp/home-assistant.ts
@@ -170,8 +170,9 @@ export function createHomeAssistantServer(
             }),
           ]
 
+          const llm = runtime.llmFactory()
           msgs = await firstValueFrom(
-            runtime.llm
+            llm
               .executePromptWithTools(
                 callServicePrompt(prompt, entity_ids),
                 tools

--- a/server/mcp/scheduler.ts
+++ b/server/mcp/scheduler.ts
@@ -157,6 +157,7 @@ export function createSchedulerServer(
         const rows = await db
           .selectFrom('signals')
           .where('automationHash', '=', automationHash)
+          .where('isDead', '!=', true)
           .select(['id', 'type', 'data'])
           .execute()
 
@@ -185,8 +186,9 @@ export function createSchedulerServer(
       i(`Cancelling all scheduled triggers for automation ${automationHash}`)
       try {
         const rows = await db
-          .deleteFrom('signals')
+          .updateTable('signals')
           .where('automationHash', '=', automationHash)
+          .set({ isDead: true })
           .execute()
 
         i(

--- a/server/run-evals.ts
+++ b/server/run-evals.ts
@@ -45,57 +45,57 @@ async function* combine<T1, T2>(generators: AsyncGenerator<T1, T2, void>[]) {
   }
 }
 
-export function runAllEvals(llm: LargeLanguageProvider) {
+export function runAllEvals(llmFactory: () => LargeLanguageProvider) {
   return combine([
     // Simple smoke tests
-    smokeTestEval(llm),
-    smokeTestToolsEval(llm),
+    smokeTestEval(llmFactory),
+    smokeTestToolsEval(llmFactory),
 
     // Home Assistant general evals
-    listEntitiesEval(llm),
-    bulkLightOperationsEval(llm),
-    multiEntityStatusEval(llm),
-    climateControlEval(llm),
-    sceneActivationEval(llm),
-    entityAttributeQueryEval(llm),
-    complexAutomationEval(llm),
+    listEntitiesEval(llmFactory),
+    bulkLightOperationsEval(llmFactory),
+    multiEntityStatusEval(llmFactory),
+    climateControlEval(llmFactory),
+    sceneActivationEval(llmFactory),
+    entityAttributeQueryEval(llmFactory),
+    complexAutomationEval(llmFactory),
 
     // Call service specific evals
-    listServicesEval(llm),
-    lightControlEval(llm),
-    lightBrightnessEval(llm),
-    lightColorEval(llm),
-    multipleEntityControlEval(llm),
-    mediaPlayerControlEval(llm),
-    climateControlTemperatureEval(llm),
-    climateControlModeEval(llm),
+    listServicesEval(llmFactory),
+    lightControlEval(llmFactory),
+    lightBrightnessEval(llmFactory),
+    lightColorEval(llmFactory),
+    multipleEntityControlEval(llmFactory),
+    mediaPlayerControlEval(llmFactory),
+    climateControlTemperatureEval(llmFactory),
+    climateControlModeEval(llmFactory),
 
     // Notification specific evals
-    listNotifyTargetsEval(llm),
-    listPeopleEval(llm),
-    notifyPersonEval(llm),
-    notifyWithTitleEval(llm),
-    notifyMultiplePeopleEval(llm),
-    notifyEveryoneEval(llm),
-    notifySpecificDeviceEval(llm),
+    listNotifyTargetsEval(llmFactory),
+    listPeopleEval(llmFactory),
+    notifyPersonEval(llmFactory),
+    notifyWithTitleEval(llmFactory),
+    notifyMultiplePeopleEval(llmFactory),
+    notifyEveryoneEval(llmFactory),
+    notifySpecificDeviceEval(llmFactory),
 
     // Scheduler evals
-    simplestSchedulerEval(llm),
-    evalAbsoluteTimePrompts(llm),
-    evalCronPrompts(llm),
-    evalMixedPrompts(llm),
-    evalRelativeTimePrompts(llm),
-    evalStateRegexPrompts(llm),
+    simplestSchedulerEval(llmFactory),
+    evalAbsoluteTimePrompts(llmFactory),
+    evalCronPrompts(llmFactory),
+    evalMixedPrompts(llmFactory),
+    evalRelativeTimePrompts(llmFactory),
+    evalStateRegexPrompts(llmFactory),
   ])
 }
 
-export function runQuickEvals(llm: LargeLanguageProvider) {
+export function runQuickEvals(llmFactory: () => LargeLanguageProvider) {
   return combine([
-    smokeTestToolsEval(llm),
-    simplestSchedulerEval(llm),
-    bulkLightOperationsEval(llm),
-    lightBrightnessEval(llm),
-    mediaPlayerControlEval(llm),
-    notifyMultiplePeopleEval(llm),
+    smokeTestToolsEval(llmFactory),
+    simplestSchedulerEval(llmFactory),
+    bulkLightOperationsEval(llmFactory),
+    lightBrightnessEval(llmFactory),
+    mediaPlayerControlEval(llmFactory),
+    notifyMultiplePeopleEval(llmFactory),
   ])
 }

--- a/server/workflow/automation-runtime.ts
+++ b/server/workflow/automation-runtime.ts
@@ -52,7 +52,7 @@ export interface SignalledAutomation {
 
 export interface AutomationRuntime extends SubscriptionLike {
   readonly api: HomeAssistantApi
-  readonly llm: LargeLanguageProvider
+  readonly llmFactory: () => LargeLanguageProvider
   readonly db: Kysely<Schema>
   readonly timezone: string // "America/Los_Angeles" etc
   readonly notebookDirectory: string | undefined
@@ -93,12 +93,11 @@ export class LiveAutomationRuntime
     api?: HomeAssistantApi,
     notebookDirectory?: string
   ) {
-    const llm = createDefaultLLMProvider(config)
     const db = await createDatabaseViaEnv()
 
     return new LiveAutomationRuntime(
       api ?? (await LiveHomeAssistantApi.createViaConfig(config)),
-      llm,
+      () => createDefaultLLMProvider(config),
       db,
       config.timezone ?? 'Etc/UTC',
       notebookDirectory
@@ -107,7 +106,7 @@ export class LiveAutomationRuntime
 
   constructor(
     readonly api: HomeAssistantApi,
-    readonly llm: LargeLanguageProvider,
+    readonly llmFactory: () => LargeLanguageProvider,
     readonly db: Kysely<Schema>,
     readonly timezone: string,
     notebookDirectory?: string

--- a/server/workflow/execution-step.ts
+++ b/server/workflow/execution-step.ts
@@ -33,8 +33,9 @@ export async function runExecutionForAutomation(
 
   const tools = createBuiltinServers(runtime, automation)
 
+  const llm = runtime.llmFactory()
   const msgs = await lastValueFrom(
-    runtime.llm
+    llm
       .executePromptWithTools(
         prompt(
           runtime,

--- a/server/workflow/execution-step.ts
+++ b/server/workflow/execution-step.ts
@@ -19,6 +19,7 @@ export async function runExecutionForAutomation(
     .selectFrom('signals')
     .selectAll()
     .where('id', '==', signalId)
+    .where('isDead', '!=', true)
     .executeTakeFirst()
 
   if (!signal) {

--- a/server/workflow/scheduler-step.ts
+++ b/server/workflow/scheduler-step.ts
@@ -19,6 +19,7 @@ export async function rescheduleAutomations(
     const automationRecord = await runtime.db
       .selectFrom('signals')
       .where('automationHash', '=', automation.hash)
+      .where('isDead', '!=', true)
       .select('id')
       .executeTakeFirst()
 

--- a/server/workflow/scheduler-step.ts
+++ b/server/workflow/scheduler-step.ts
@@ -43,8 +43,9 @@ export async function runSchedulerForAutomation(
   const tools = createDefaultSchedulerTools(runtime, automation)
 
   const memory = await fs.readFile(getMemoryFile(runtime), 'utf-8')
+  const llm = runtime.llmFactory()
   const msgs = await lastValueFrom(
-    runtime.llm
+    llm
       .executePromptWithTools(
         schedulerPrompt(runtime, automation.contents, memory),
         tools

--- a/site/App.tsx
+++ b/site/App.tsx
@@ -40,7 +40,7 @@ function AppSidebar({ onPageClicked }: AppSidebarProps) {
 
       onPageClicked(page)
     },
-    [isMobile]
+    [isMobile, onPageClicked, toggleSidebar]
   )
 
   const bg = isMobile ? 'bg-white' : ''

--- a/site/components/chat-message.tsx
+++ b/site/components/chat-message.tsx
@@ -8,7 +8,6 @@ import {
   CollapsibleTrigger,
 } from '@radix-ui/react-collapsible'
 import { ChevronDown } from 'lucide-react'
-import type { Root } from 'mdast'
 import { JSX, useMemo, useState } from 'react'
 import { Remark } from 'react-remark'
 

--- a/site/components/model-selector.tsx
+++ b/site/components/model-selector.tsx
@@ -1,7 +1,6 @@
 import { usePromise } from '@anaisbetts/commands'
 import { Check, Copy } from 'lucide-react'
-import { useMemo, useState } from 'react'
-import React from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { firstValueFrom } from 'rxjs'
 
 import { Button } from '@/components/ui/button'
@@ -46,7 +45,7 @@ export function ModelSelector({
     return models
   }, [api, driver, model, disabled])
 
-  const handleCopy = async () => {
+  const handleCopy = useCallback(async () => {
     if (!model) return
     try {
       await navigator.clipboard.writeText(model)
@@ -56,7 +55,7 @@ export function ModelSelector({
     } catch (err) {
       console.error('Failed to copy model name: ', err)
     }
-  }
+  }, [model])
 
   return useMemo(
     () =>
@@ -89,7 +88,7 @@ export function ModelSelector({
             <Button
               variant="outline"
               size="icon"
-              onClick={handleCopy}
+              onClick={void handleCopy}
               disabled={!model || disabled || isCopied}
               aria-label="Copy model name"
             >
@@ -123,6 +122,17 @@ export function ModelSelector({
           </div>
         ),
       }),
-    [modelList]
+    [
+      className,
+      disabled,
+      driver,
+      handleCopy,
+      isCopied,
+      model,
+      modelList,
+      onModelChange,
+      onOpenChange,
+      triggerClassName,
+    ]
   )
 }

--- a/site/components/ws-provider.tsx
+++ b/site/components/ws-provider.tsx
@@ -1,5 +1,5 @@
 import { useObservable } from '@anaisbetts/commands'
-import { ReactNode, createContext, useContext, useEffect } from 'react'
+import { ReactNode, createContext, useContext } from 'react'
 import {
   EMPTY,
   Observable,
@@ -50,7 +50,7 @@ function connectApiToWs() {
                 let resp: any
                 try {
                   resp = JSON.parse(msg.data)
-                } catch (e) {
+                } catch {
                   return EMPTY
                 }
 

--- a/site/pages/chat.tsx
+++ b/site/pages/chat.tsx
@@ -182,7 +182,7 @@ export default function Chat() {
         ),
         null: () => <div className="text-sm italic">Select a driver</div>,
       }),
-    [driverList]
+    [driver, driverList, handleDriverChange]
   )
 
   return (
@@ -212,7 +212,7 @@ export default function Chat() {
       </div>
 
       <div className="border-border border-t p-4">
-        <form onSubmit={sendPrompt} className="flex gap-2">
+        <form onSubmit={void sendPrompt} className="flex gap-2">
           <Input
             ref={inputRef}
             value={input}

--- a/site/pages/config.tsx
+++ b/site/pages/config.tsx
@@ -136,7 +136,7 @@ export default function Config() {
         <h2 className="text-lg font-semibold">Configuration</h2>
         <SaveButton
           saveResult={saveResult}
-          onClick={() => saveConfig()}
+          onClick={() => void saveConfig()}
           isSaved={isSaved}
         />
       </div>
@@ -400,7 +400,7 @@ export default function Config() {
           })}
           <SaveButton
             saveResult={saveResult}
-            onClick={() => saveConfig()}
+            onClick={() => void saveConfig()}
             isSaved={isSaved}
           />
         </div>

--- a/site/pages/evals.tsx
+++ b/site/pages/evals.tsx
@@ -1,6 +1,6 @@
 import { useCommand, usePromise } from '@anaisbetts/commands'
 import { Beaker, Play } from 'lucide-react'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { firstValueFrom, share, toArray } from 'rxjs'
 
 import { Button } from '@/components/ui/button'
@@ -121,7 +121,7 @@ export default function Evals() {
         ),
         null: () => <div className="text-sm italic">Select a driver</div>,
       }),
-    [driverList]
+    [driver, driverList]
   )
 
   return (
@@ -182,7 +182,7 @@ export default function Evals() {
           <Button
             onClick={(e) => {
               e.preventDefault()
-              runEvals()
+              void runEvals()
             }}
             disabled={evalCommand.isPending() || !model.trim() || !driver}
             className="flex gap-2"

--- a/site/pages/logs.tsx
+++ b/site/pages/logs.tsx
@@ -42,7 +42,7 @@ export default function Logs() {
   // Fetch logs on component mount if API is available
   useEffect(() => {
     if (api) {
-      fetchLogsCmd()
+      void fetchLogsCmd()
     }
   }, [api, fetchLogsCmd])
 
@@ -58,9 +58,7 @@ export default function Logs() {
     })
   }
 
-  const refreshLogs = () => {
-    fetchLogsCmd()
-  }
+  const refreshLogs = () => void fetchLogsCmd()
 
   const filteredLogs = useMemo(() => {
     return logs

--- a/site/pages/pending.tsx
+++ b/site/pages/pending.tsx
@@ -17,28 +17,23 @@ import { SignalHandlerInfo } from '../../shared/types'
 import { useWebSocket } from '../components/ws-provider'
 
 export default function PendingAutomations() {
-  const [signals, setSignals] = useState<SignalHandlerInfo[]>([])
   const { api } = useWebSocket()
 
   // Define a command to fetch scheduled signals
-  const [fetchSignalsCmd, fetchSignalsResult, resetFetchSignals] =
-    useCommand(async () => {
-      if (!api) return []
-      const result = await firstValueFrom(api.getScheduledSignals())
-      setSignals(result)
-      return result
-    }, [api])
+  const [fetchSignalsCmd, fetchSignalsResult] = useCommand(async () => {
+    if (!api) return []
+    const result = await firstValueFrom(api.getScheduledSignals())
+    return result
+  }, [api])
 
   // Fetch signals on component mount if API is available
   useEffect(() => {
     if (api) {
-      fetchSignalsCmd()
+      void fetchSignalsCmd()
     }
   }, [api, fetchSignalsCmd])
 
-  const refreshSignals = () => {
-    fetchSignalsCmd()
-  }
+  const refreshSignals = () => fetchSignalsCmd()
 
   const signalsContent = fetchSignalsResult.mapOrElse({
     pending: () => (
@@ -47,13 +42,13 @@ export default function PendingAutomations() {
       </div>
     ),
     ok: (result) =>
-      signals.length === 0 ? (
+      result?.length === 0 ? (
         <div className="text-muted-foreground p-8 text-center">
           No pending automations found
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 auto-rows-fr">
-          {signals.map((signal, index) => (
+          {result?.map((signal, index) => (
             <SignalCard key={index} signal={signal} />
           ))}
         </div>
@@ -70,7 +65,7 @@ export default function PendingAutomations() {
       <div className="border-border flex items-center justify-between border-b p-4">
         <h2 className="text-lg font-semibold">Pending Automations</h2>
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="icon" onClick={refreshSignals}>
+          <Button variant="outline" size="icon" onClick={void refreshSignals}>
             <RotateCw size={18} />
           </Button>
         </div>


### PR DESCRIPTION
Fix a ton of bugs:

* When MCP servers time out, the associated Client just ends up giga-wedged, we need a way to restart it.
* We weren't completely restarting the AutomationRuntime when the config changed, now we completely tear down and restart it
* When we added `isDead` to signals, we forgot to actually update that everywhere
* Fix a million bugs related to ESLint not running correctly on tsx files