### PR TITLE
Move toward "model-with-driver" and away from default models per driver

### DIFF
--- a/mocks/mock.config.toml
+++ b/mocks/mock.config.toml
@@ -1,6 +1,8 @@
 ha_base_url = "https://foo"
 ha_token = "token"
 timezone = "America/Los_Angeles"
+automation_model = "anthropic/claude-3-5-sonnet-20240620"
+vision_model = "openai/gpt-4o"
 
 [anthropic]
 key = "wiefjef"

--- a/server/api.ts
+++ b/server/api.ts
@@ -207,7 +207,7 @@ export class ServerWebsocketApiImpl implements ServerWebsocketApi {
         )
 
         previousMessages = msgs
-        const llm = this.runtime.llmFactory()
+        const llm = this.runtime.llmFactory('automation') // XXX: This is hardcoded above to return the mwd they want
         if (prevMsgs.length > 0) {
           // If we are in a continuing conversation, we don't include the system
           // prompt

--- a/server/api.ts
+++ b/server/api.ts
@@ -67,7 +67,7 @@ export class ServerWebsocketApiImpl implements ServerWebsocketApi {
     }
 
     return of({
-      automationModelWithDriver: this.config.automationModel,
+      automationModelWithDriver: this.config.automationModel ?? '',
       drivers,
     })
   }

--- a/server/api.ts
+++ b/server/api.ts
@@ -27,11 +27,7 @@ import {
 import { AppConfig } from '../shared/types'
 import { pick } from '../shared/utility'
 import { fetchAutomationLogs } from './db'
-import {
-  createBuiltinServers,
-  createDefaultLLMProvider,
-  getDefaultModelForDriver,
-} from './llm'
+import { createBuiltinServers, createDefaultLLMProvider } from './llm'
 import { i } from './logging'
 import { getSystemPrompt } from './prompts'
 import { runAllEvals, runQuickEvals } from './run-evals'
@@ -53,7 +49,10 @@ export class ServerWebsocketApiImpl implements ServerWebsocketApi {
     public evalMode: boolean
   ) {}
 
-  getDriverList(): Observable<{ defaultDriver: string; drivers: string[] }> {
+  getDriverList(): Observable<{
+    automationModelWithDriver: string
+    drivers: string[]
+  }> {
     const drivers: string[] = []
     if (this.config.anthropicApiKey) {
       drivers.push('anthropic')
@@ -66,17 +65,20 @@ export class ServerWebsocketApiImpl implements ServerWebsocketApi {
         ...this.config.openAIProviders.map((x) => x.providerName ?? 'openai')
       )
     }
-    const defaultDriver = this.config.llm ?? drivers[0]
-    return of({ defaultDriver, drivers })
+
+    return of({
+      automationModelWithDriver: this.config.automationModel,
+      drivers,
+    })
   }
 
-  getModelListForDriver(
-    driver: string
-  ): Observable<{ defaultModel?: string; models: string[] }> {
-    const llm = createDefaultLLMProvider(this.config, driver.toLowerCase())
+  getModelListForDriver(driver: string): Observable<{ models: string[] }> {
+    const llm = createDefaultLLMProvider(this.config, {
+      modelWithDriver: `${driver}/dontcare`,
+    })
+
     return from(
       llm.getModelList().then((models) => ({
-        defaultModel: getDefaultModelForDriver(this.config, driver),
         models,
       }))
     )
@@ -160,14 +162,13 @@ export class ServerWebsocketApiImpl implements ServerWebsocketApi {
 
   handlePromptRequest(
     prompt: string,
-    model?: string,
-    driver?: string,
+    modelWithDriver: string,
     previousConversationId?: number,
     typeHint?: TypeHint
   ): Observable<MessageParamWithExtras> {
     const rqRuntime = new LiveAutomationRuntime(
       this.runtime.api,
-      () => createDefaultLLMProvider(this.config, driver, model),
+      () => createDefaultLLMProvider(this.config, { modelWithDriver }),
       this.runtime.db,
       this.notebookDirectory
     )
@@ -291,8 +292,7 @@ export class ServerWebsocketApiImpl implements ServerWebsocketApi {
   }
 
   runEvals(
-    model: string,
-    driver: string,
+    modelWithDriver: string,
     type: 'all' | 'quick',
     count: number
   ): Observable<ScenarioResult> {
@@ -306,7 +306,9 @@ export class ServerWebsocketApiImpl implements ServerWebsocketApi {
     return from(
       counter.pipe(
         concatMap(() =>
-          runEvals(() => createDefaultLLMProvider(this.config, driver, model))
+          runEvals(() =>
+            createDefaultLLMProvider(this.config, { modelWithDriver })
+          )
         )
       )
     )

--- a/server/index.ts
+++ b/server/index.ts
@@ -191,7 +191,9 @@ async function evalCommand(options: {
 
     const evalFunction = options.quick ? runQuickEvals : runAllEvals
     for await (const result of evalFunction(() =>
-      createDefaultLLMProvider(config, driver, model)
+      createDefaultLLMProvider(config, {
+        modelWithDriver: `${driver}/${model}`,
+      })
     )) {
       results.push(result)
       if (options.verbose) {

--- a/server/llm.ts
+++ b/server/llm.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs'
 
 import { Automation } from '../shared/types'
 import { AppConfig } from '../shared/types'
+import { parseModelWithDriverString } from '../shared/utility'
 import { AnthropicLargeLanguageProvider } from './anthropic'
 import { createCueServer } from './mcp/cue'
 import { createHomeAssistantServer } from './mcp/home-assistant'
@@ -139,18 +140,4 @@ export function connectServerToClient(client: Client, server: Server) {
   const [cli, srv] = InMemoryTransport.createLinkedPair()
   void client.connect(cli)
   void server.connect(srv)
-}
-
-export function parseModelWithDriverString(modelWithDriver: string) {
-  const [driver, model] = modelWithDriver.split('/')
-
-  if (!/^[a-z]+$/i.test(driver)) {
-    throw new Error(`Invalid driver: ${driver}`)
-  }
-
-  if (!model) {
-    throw new Error(`No model provided: ${modelWithDriver}`)
-  }
-
-  return { driver, model }
 }

--- a/server/llm.ts
+++ b/server/llm.ts
@@ -5,7 +5,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { Observable } from 'rxjs'
 
-import { Automation } from '../shared/types'
+import { Automation, LLMFactoryType } from '../shared/types'
 import { AppConfig } from '../shared/types'
 import { parseModelWithDriverString } from '../shared/utility'
 import { AnthropicLargeLanguageProvider } from './anthropic'
@@ -38,7 +38,7 @@ export function createDefaultLLMProvider(
       }
     | {
         modelWithDriver?: never
-        type?: 'automation' | 'vision'
+        type?: LLMFactoryType
       }
 ): LargeLanguageProvider {
   let mwd = opts?.modelWithDriver

--- a/server/mcp/home-assistant.ts
+++ b/server/mcp/home-assistant.ts
@@ -181,9 +181,7 @@ export function createHomeAssistantServer(
           return resized
         })
 
-        // XXX Here is where we would put a "Create an image-friendly LLM"
-        const llm = runtime.llmFactory()
-
+        const llm = runtime.llmFactory('vision')
         const msg = await lastValueFrom(
           llm.executePromptWithTools(
             analyzeImagePrompt(prompt),
@@ -226,7 +224,7 @@ export function createHomeAssistantServer(
             }),
           ]
 
-          const llm = runtime.llmFactory()
+          const llm = runtime.llmFactory('automation')
           msgs = await firstValueFrom(
             llm
               .executePromptWithTools(

--- a/server/openai-proxy.ts
+++ b/server/openai-proxy.ts
@@ -38,7 +38,7 @@ export function setupOpenAIProxy(app: Hono<BlankEnv, BlankSchema, '/'>) {
     }
 
     // Create LLM provider using runtime
-    const llm = runtime!.llmFactory()
+    const llm = runtime!.llmFactory('automation')
 
     // Convert OpenAI messages to Anthropic format
     const anthropicMessages: MessageParam[] = []

--- a/server/workflow/automation-runtime.ts
+++ b/server/workflow/automation-runtime.ts
@@ -19,7 +19,7 @@ import {
 } from 'rxjs'
 
 import { SerialSubscription } from '../../shared/serial-subscription'
-import { Automation } from '../../shared/types'
+import { Automation, LLMFactoryType } from '../../shared/types'
 import { AppConfig } from '../../shared/types'
 import { saveConfig } from '../config'
 import { createDatabaseViaEnv } from '../db'
@@ -49,7 +49,7 @@ export interface SignalledAutomation {
 
 export interface AutomationRuntime extends SubscriptionLike {
   readonly api: HomeAssistantApi
-  readonly llmFactory: () => LargeLanguageProvider
+  readonly llmFactory: (type: LLMFactoryType) => LargeLanguageProvider
   readonly db: Kysely<Schema>
   readonly timezone: string // "America/Los_Angeles" etc
   readonly notebookDirectory: string | undefined
@@ -86,7 +86,7 @@ export class LiveAutomationRuntime
 
     return new LiveAutomationRuntime(
       api ?? (await LiveHomeAssistantApi.createViaConfig(config)),
-      () => createDefaultLLMProvider(config),
+      (type: LLMFactoryType) => createDefaultLLMProvider(config, { type }),
       db,
       config.timezone ?? 'Etc/UTC',
       notebookDirectory
@@ -95,7 +95,7 @@ export class LiveAutomationRuntime
 
   constructor(
     readonly api: HomeAssistantApi,
-    readonly llmFactory: () => LargeLanguageProvider,
+    readonly llmFactory: (type: LLMFactoryType) => LargeLanguageProvider,
     readonly db: Kysely<Schema>,
     readonly timezone: string,
     notebookDirectory?: string

--- a/server/workflow/execution-step.ts
+++ b/server/workflow/execution-step.ts
@@ -42,7 +42,7 @@ export async function runExecutionForAutomation(
     onImageReferenced,
   })
 
-  const llm = runtime.llmFactory()
+  const llm = runtime.llmFactory('automation')
   const msgs = await lastValueFrom(
     llm
       .executePromptWithTools(

--- a/server/workflow/scheduler-step.ts
+++ b/server/workflow/scheduler-step.ts
@@ -44,7 +44,7 @@ export async function runSchedulerForAutomation(
   const tools = createDefaultSchedulerTools(runtime, automation)
 
   const memory = await fs.readFile(getMemoryFile(runtime), 'utf-8')
-  const llm = runtime.llmFactory()
+  const llm = runtime.llmFactory('automation')
   const msgs = await lastValueFrom(
     llm
       .executePromptWithTools(

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -16,23 +16,22 @@ export type MessageParamWithExtras = MessageParam & {
 export interface ServerWebsocketApi {
   handlePromptRequest(
     prompt: string,
-    model?: string,
-    driver?: string,
+    modelWithDriver: string,
     previousConversationId?: number,
     typeHint?: TypeHint
   ): Observable<MessageParamWithExtras>
 
   runEvals(
-    model: string,
-    driver: string,
+    modelWithDriver: string,
     type: 'all' | 'quick',
     count: number
   ): Observable<ScenarioResult>
 
-  getModelListForDriver(
-    driver: string
-  ): Observable<{ defaultModel?: string; models: string[] }>
-  getDriverList(): Observable<{ defaultDriver: string; drivers: string[] }>
+  getModelListForDriver(driver: string): Observable<{ models: string[] }>
+  getDriverList(): Observable<{
+    automationModelWithDriver: string
+    drivers: string[]
+  }>
 
   getAutomationLogs(beforeTimestamp?: Date): Observable<AutomationLogEntry[]>
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -102,13 +102,11 @@ export interface AppConfig {
    */
   timezone?: string
 
-  llm?: string // either 'anthropic', 'ollama', or a provider name in openAIProviders
+  automationModel: string
+  visionModel: string
 
   anthropicApiKey?: string
-  anthropicModel?: string
-
   ollamaHost?: string
-  ollamaModel?: string
 
   openAIProviders?: OpenAIProviderConfig[] // Array for multiple OpenAI configs
 }
@@ -117,7 +115,6 @@ export interface OpenAIProviderConfig {
   providerName?: string // Name for this provider configuration, the default is 'openai'
   baseURL?: string
   apiKey?: string
-  model?: string
 }
 
 /**

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -102,8 +102,8 @@ export interface AppConfig {
    */
   timezone?: string
 
-  automationModel: string
-  visionModel: string
+  automationModel?: string
+  visionModel?: string
 
   anthropicApiKey?: string
   ollamaHost?: string

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,6 +1,7 @@
 import { MessageParam } from '@anthropic-ai/sdk/resources/index.mjs'
 
 export type SignalType = 'cron' | 'state' | 'event' | 'offset' | 'time'
+export type LLMFactoryType = 'automation' | 'vision'
 
 export type AutomationType =
   | 'manual'

--- a/shared/utility.ts
+++ b/shared/utility.ts
@@ -118,3 +118,17 @@ export const guaranteedThrottle =
       switchAll()
     )
   }
+
+export function parseModelWithDriverString(modelWithDriver: string) {
+  const [driver, model] = modelWithDriver.split('/')
+
+  if (!/^[a-z]+$/i.test(driver)) {
+    throw new Error(`Invalid driver: ${driver}`)
+  }
+
+  if (!model) {
+    throw new Error(`No model provided: ${modelWithDriver}`)
+  }
+
+  return { driver, model }
+}

--- a/shared/utility.ts
+++ b/shared/utility.ts
@@ -122,7 +122,7 @@ export const guaranteedThrottle =
 export function parseModelWithDriverString(modelWithDriver: string) {
   const [driver, model] = modelWithDriver.split('/')
 
-  if (!/^[a-z]+$/i.test(driver)) {
+  if (!/^[a-z]+$/i.test(driver) || driver.length === 0) {
     throw new Error(`Invalid driver: ${driver}`)
   }
 

--- a/site/components/llm-selector.tsx
+++ b/site/components/llm-selector.tsx
@@ -64,8 +64,10 @@ export function DriverSelector({
           </Select>
         )
       },
-      err: () => (
-        <div className="text-sm text-red-500">Failed to load drivers</div>
+      err: (e) => (
+        <div className="text-sm text-red-500">
+          Failed to load drivers: {e.toString()}
+        </div>
       ),
       pending: () => (
         <div className="flex h-10 w-[180px] items-center justify-center">

--- a/site/components/llm-selector.tsx
+++ b/site/components/llm-selector.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
+import { parseModelWithDriverString } from '../../shared/utility'
 import { Button } from './ui/button'
 import { useWebSocket } from './ws-provider'
 
@@ -29,10 +30,14 @@ export function DriverSelector({
 
   const driverList = usePromise(async () => {
     if (!api) return { defaultDriver: '', drivers: [] }
-    const { defaultDriver, drivers } = await firstValueFrom(api.getDriverList())
+    const { automationModelWithDriver, drivers } = await firstValueFrom(
+      api.getDriverList()
+    )
 
-    onDriverChange(defaultDriver)
-    return { defaultDriver, drivers }
+    const { driver } = parseModelWithDriverString(automationModelWithDriver)
+
+    onDriverChange(driver)
+    return { defaultDriver: driver, drivers }
   }, [api])
 
   return useResult(
@@ -99,7 +104,6 @@ export function ModelSelector({
     if (!api || !driver) return { defaultModel: '', models: [] }
     const ret = await firstValueFrom(api.getModelListForDriver(driver))
 
-    if (ret.defaultModel) onModelChange(ret.defaultModel)
     return ret
   }, [api, driver])
 

--- a/site/hooks/use-mobile.ts
+++ b/site/hooks/use-mobile.ts
@@ -16,6 +16,5 @@ export function useIsMobile() {
     return () => mql.removeEventListener('change', onChange)
   }, [])
 
-  console.log(`isMobile: ${isMobile}`)
   return !!isMobile
 }

--- a/site/pages/chat.tsx
+++ b/site/pages/chat.tsx
@@ -44,8 +44,7 @@ export default function Chat() {
     const msgCall = api
       .handlePromptRequest(
         input,
-        model,
-        driver,
+        `${driver}/${model}`,
         currentConversationId,
         isDebugMode ? 'debug' : 'chat'
       )

--- a/site/pages/config.tsx
+++ b/site/pages/config.tsx
@@ -1,6 +1,6 @@
-import { useCommand, usePromise } from '@anaisbetts/commands'
+import { useCommand, usePromise, useResult } from '@anaisbetts/commands'
 import { Check, Save } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { firstValueFrom } from 'rxjs'
 
 import {
@@ -32,7 +32,10 @@ const timezones = Intl.supportedValuesOf('timeZone')
 
 export default function Config() {
   const { api } = useWebSocket()
-  const [config, setConfig] = useState<AppConfig>({})
+  const [config, setConfig] = useState<AppConfig>({
+    automationModel: '',
+    visionModel: '',
+  })
   const [isSaved, setIsSaved] = useState(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const [showCompletionDialog, setShowCompletionDialog] = useState(false)
@@ -40,7 +43,7 @@ export default function Config() {
 
   // Fetch initial config
   const [fetchConfig, configResult] = useCommand(async () => {
-    if (!api) return {}
+    if (!api) return { automationModel: '', visionModel: '' }
     return await firstValueFrom(api.getConfig())
   }, [api])
 
@@ -165,6 +168,25 @@ export default function Config() {
     setShowCompletionDialog(false)
   }, [])
 
+  const saveResultContent = useResult(saveResult, {
+    ok: () => null,
+    err: (error) => (
+      <div className="text-red-500">
+        Failed to save configuration: {error.message}
+      </div>
+    ),
+    pending: () => null,
+    null: () => null,
+  })
+
+  const timezonesSelectContent = useMemo(() => {
+    return timezones.map((tz) => (
+      <SelectItem key={tz} value={tz}>
+        {tz}
+      </SelectItem>
+    ))
+  }, [])
+
   // Show loading state
   if (configResult.isPending()) {
     return (
@@ -238,16 +260,52 @@ export default function Config() {
                   <SelectValue placeholder="Select timezone..." />
                 </SelectTrigger>
 
-                <SelectContent>
-                  {timezones.map((tz) => (
-                    <SelectItem key={tz} value={tz}>
-                      {tz}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
+                <SelectContent>{timezonesSelectContent}</SelectContent>
               </Select>
               <p className="text-xs text-gray-500">
                 Select your local IANA timezone.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Model Configuration */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Models</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="automationModel" className="text-sm font-medium">
+                Automation Model
+              </label>
+              <Input
+                id="automationModel"
+                name="automationModel"
+                value={config.automationModel || ''}
+                onChange={handleChange}
+                placeholder="anthropic/claude-3-5-sonnet-20240620"
+              />
+              <p className="text-xs text-gray-500">
+                Format: driver/model (e.g.,
+                anthropic/claude-3-5-sonnet-20240620, openai/gpt-4-turbo,
+                ollama/llama3)
+              </p>
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="visionModel" className="text-sm font-medium">
+                Vision Model
+              </label>
+              <Input
+                id="visionModel"
+                name="visionModel"
+                value={config.visionModel || ''}
+                onChange={handleChange}
+                placeholder="openai/gpt-4o"
+              />
+              <p className="text-xs text-gray-500">
+                Format: driver/model (e.g., openai/gpt-4o,
+                anthropic/claude-3-5-sonnet-20240620)
               </p>
             </div>
           </CardContent>
@@ -409,16 +467,8 @@ export default function Config() {
 
         {/* Save Result Status and Button */}
         <div className="flex items-center justify-end py-4">
-          {saveResult.mapOrElse({
-            ok: () => null,
-            err: (error) => (
-              <div className="text-red-500 mr-4">
-                Failed to save: {error.message}
-              </div>
-            ),
-            pending: () => null,
-            null: () => null,
-          })}
+          {saveResultContent}
+
           <SaveButton
             saveResult={saveResult}
             onClick={saveConfig}
@@ -481,7 +531,7 @@ interface SaveButtonProps {
 }
 
 function SaveButton({ saveResult, onClick, isSaved }: SaveButtonProps) {
-  const buttonContent = saveResult.mapOrElse({
+  const buttonContent = useResult(saveResult, {
     pending: () => (
       <div className="flex items-center gap-2">
         <div className="h-4 w-4 animate-spin rounded-full border-2 border-t-transparent"></div>

--- a/site/pages/config.tsx
+++ b/site/pages/config.tsx
@@ -91,7 +91,11 @@ export default function Config() {
 
   // Handle OpenAI provider changes
   const handleOpenAIProviderChange = useCallback(
-    (index: number, field: keyof OpenAIProviderConfig, value: string) => {
+    (
+      index: number,
+      field: keyof Omit<OpenAIProviderConfig, 'model'>,
+      value: string
+    ) => {
       setConfig((prev) => {
         const updatedProviders = [...(prev.openAIProviders || [])]
 
@@ -249,31 +253,6 @@ export default function Config() {
           </CardContent>
         </Card>
 
-        {/* LLM Selection */}
-        <Card>
-          <CardHeader>
-            <CardTitle>LLM Provider</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <label htmlFor="llm" className="text-sm font-medium">
-                Default LLM Provider
-              </label>
-              <Input
-                id="llm"
-                name="llm"
-                value={config.llm || ''}
-                onChange={handleChange}
-                placeholder="anthropic, ollama, or provider name"
-              />
-              <p className="text-xs text-gray-500">
-                Enter 'anthropic', 'ollama', or a provider name from your OpenAI
-                providers
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-
         {/* Anthropic Settings */}
         <Card>
           <CardHeader>
@@ -291,18 +270,6 @@ export default function Config() {
                 onChange={handleChange}
                 type="password"
                 placeholder="Anthropic API Key"
-              />
-            </div>
-            <div className="space-y-2">
-              <label htmlFor="anthropicModel" className="text-sm font-medium">
-                Model
-              </label>
-              <Input
-                id="anthropicModel"
-                name="anthropicModel"
-                value={config.anthropicModel || ''}
-                onChange={handleChange}
-                placeholder="claude-3-opus-20240229"
               />
             </div>
           </CardContent>
@@ -324,18 +291,6 @@ export default function Config() {
                 value={config.ollamaHost || ''}
                 onChange={handleChange}
                 placeholder="http://localhost:11434"
-              />
-            </div>
-            <div className="space-y-2">
-              <label htmlFor="ollamaModel" className="text-sm font-medium">
-                Model
-              </label>
-              <Input
-                id="ollamaModel"
-                name="ollamaModel"
-                value={config.ollamaModel || ''}
-                onChange={handleChange}
-                placeholder="llama3"
               />
             </div>
           </CardContent>
@@ -411,16 +366,6 @@ export default function Config() {
                     }
                     type="password"
                     placeholder="API Key"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label className="text-sm font-medium">Model</label>
-                  <Input
-                    value={provider.model || ''}
-                    onChange={(e) =>
-                      handleOpenAIProviderChange(index, 'model', e.target.value)
-                    }
-                    placeholder="gpt-4-turbo"
                   />
                 </div>
               </div>

--- a/site/pages/evals.tsx
+++ b/site/pages/evals.tsx
@@ -31,7 +31,10 @@ export default function Evals() {
     setResults([])
     const before = performance.now()
 
-    const evalCall = api.runEvals(model, driver, evalType, count).pipe(share())
+    const evalCall = api
+      .runEvals(`${driver}/${model}`, evalType, count)
+      .pipe(share())
+
     const evalResults: ScenarioResult[] = []
 
     evalCall.subscribe({


### PR DESCRIPTION
Now, config.toml has two fields `automation_model` and `vision_model` - they use the format `driver/model` so `openai/gpt4.1`

