### PR TITLE
Run beatrix as PID 1 when containerized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ EXPOSE ${PORT}
 
 # Use architecture detection to run the correct binary
 CMD if [ "$(uname -m)" = "x86_64" ]; then \
-    /dist/beatrix-server-linux-x64 serve -n ${NOTEBOOK_DIR}; \
+    exec /dist/beatrix-server-linux-x64 serve -n ${NOTEBOOK_DIR}; \
     elif [ "$(uname -m)" = "aarch64" ]; then \
-    /dist/beatrix-server-linux-arm64 serve -n ${NOTEBOOK_DIR}; \
+    exec /dist/beatrix-server-linux-arm64 serve -n ${NOTEBOOK_DIR}; \
     else \
     echo "Unsupported architecture: $(uname -m)"; \
     exit 1; \


### PR DESCRIPTION
Run beatrix with `exec` so that she's PID 1 when running in a container. This ensures that she'll receive signals (e.g. `docker stop` or hitting `Ctrl-C` in Compose) and quit immediately; otherwise, the signal gets eaten by the shell and she ends up being SIGKILL'ed 10 seconds later (or 30 seconds later on Kubernetes).